### PR TITLE
Service: removed bashism in line 30

### DIFF
--- a/save-backlight
+++ b/save-backlight
@@ -27,7 +27,7 @@ start() {
 
 	for card in $(basename /sys/class/backlight/*); do
 		if [ -e "${CACHE_DIR}/${card}" ]; then
-			local -r blight=$(cat "${CACHE_DIR}/${card}")
+			readonly blight=$(cat "${CACHE_DIR}/${card}")
 
 			if [ ${blight} -ne 0 ]; then
 				echo ${blight} > "/sys/class/backlight/${card}/brightness"


### PR DESCRIPTION
If `/bin/sh` is set to dash, openrc complains about `local -r` being a bad variable name. Also I removed inconsistency: you already used POSIX-compliant `readonly` before, with `$CACHE_DIR`