### PR TITLE
remove * in openrc-run script

### DIFF
--- a/save-backlight
+++ b/save-backlight
@@ -26,7 +26,7 @@ start()
 
 	checkpath -D -o "root:root" "${CACHE_DIR}"
 
-	for card in $(basename /sys/class/backlight/*); do
+	for card in $(ls /sys/class/backlight/); do
 		card_file="${CACHE_DIR}/${card}"
 
 		if [[ -e "${card_file}" ]]; then
@@ -36,12 +36,12 @@ start()
 				echo ${blight} > "/sys/class/backlight/${card}/brightness"
 			else
 				ewarn "Setting the brightness to zero would cause the"
-				ewarn "screen to turn off (skipping)"
+				ewarn "screen to turn off (skipping ${card})"
 			fi
 
 			unset blight
 		else
-			ewarn "Cache is empty (skipping)"
+			ewarn "Cache is empty (skipping ${card})"
 		fi
 
 		eend $? "Cannot restore the brightness of ${card}"
@@ -56,7 +56,7 @@ stop()
 
 	checkpath -D -o "root:root" "${CACHE_DIR}"
 
-	for card in $(basename /sys/class/backlight/*); do
+	for card in $(ls /sys/class/backlight/); do
 		cat "/sys/class/backlight/${card}/brightness" \
 			> "${CACHE_DIR}/${card}"
 


### PR DESCRIPTION
> https://github.com/OpenRC/openrc/blob/master/service-script-guide.md#syntax-of-service-scripts

Due in POSIX sh subset, basename * will scan root dir

In my case, if I add log in script, I will see like:
```
* Restoring the screen brightness ...
 * Cache is empty for bin (skipping)
 [ ok ]
 * Cache is empty for boot (skipping)
 [ ok ]
 * Cache is empty for dev (skipping)
 [ ok ]
 * Cache is empty for etc (skipping)
 [ ok ]
 * Cache is empty for extra (skipping)
 [ ok ]
 * Cache is empty for home (skipping)
 [ ok ]
 * Cache is empty for lib (skipping)
 [ ok ]
 * Cache is empty for lib64 (skipping)
 [ ok ]
 * Cache is empty for media (skipping)
 [ ok ]
 * Cache is empty for mnt (skipping)
 [ ok ]
 * Cache is empty for opt (skipping)
 [ ok ]
 * Cache is empty for proc (skipping)
 [ ok ]
 * Cache is empty for root (skipping)
 [ ok ]
 * Cache is empty for run (skipping)
 [ ok ]
 * Cache is empty for sbin (skipping)
 [ ok ]
 * Cache is empty for sys (skipping)
 [ ok ]
 * Cache is empty for tmp (skipping)
 [ ok ]
 * Cache is empty for usr (skipping)
 [ ok ]
 * Cache is empty for var (skipping)
```

So I also add some log for user easier debug.